### PR TITLE
Fix pizza size picker layout to show add buttons

### DIFF
--- a/app/src/main/java/com/alos895/simplepos/ui/menu/MenuScreen.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/menu/MenuScreen.kt
@@ -149,13 +149,14 @@ fun MenuScreen(
                                         ) {
                                             ExposedDropdownMenuBox(
                                                 expanded = expanded,
-                                                onExpandedChange = { expanded = !expanded }
+                                                onExpandedChange = { expanded = !expanded },
+                                                modifier = Modifier.weight(1f)
                                             ) {
                                                 OutlinedTextField(
                                                     value = "${selectedTamano.nombre} ($${"%.2f".format(selectedTamano.precioBase) })",
                                                     onValueChange = {},
                                                     readOnly = true,
-                                                    label = { Text("Tama?o") },
+                                                    label = { Text("Tamaño") },
                                                     trailingIcon = {
                                                         ExposedDropdownMenuDefaults.TrailingIcon(
                                                             expanded
@@ -184,12 +185,15 @@ fun MenuScreen(
                                                     }
                                                 }
                                             }
-                                            Button(onClick = {
-                                                cartViewModel.addToCart(
-                                                    pizza,
-                                                    selectedTamano
-                                                )
-                                            }) {
+                                            Button(
+                                                onClick = {
+                                                    cartViewModel.addToCart(
+                                                        pizza,
+                                                        selectedTamano
+                                                    )
+                                                },
+                                                modifier = Modifier.widthIn(min = 120.dp)
+                                            ) {
                                                 Text("Agregar")
                                             }
                                         }


### PR DESCRIPTION
## Summary
- constrain the pizza size selector to share horizontal space so the Add button remains visible
- correct the label text for the pizza size selector

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1751dc6c832b9edc01b95df50971