### PR TITLE
Show delivery type in order details

### DIFF
--- a/app/src/main/java/com/alos895/simplepos/ui/menu/CartViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/menu/CartViewModel.kt
@@ -182,8 +182,10 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
         val hora = formatter.format(Date(timestamp))
         val entrega = deliveryService ?: _selectedDelivery.value
         val destino = when {
-            entrega?.price ?: 0 > 0 -> if (deliveryAddress.isNotBlank()) deliveryAddress else entrega?.zona ?: "Domicilio"
-            entrega?.pickUp == true -> entrega.zona
+            entrega?.price ?: 0 > 0 ->
+                if (deliveryAddress.isNotBlank()) deliveryAddress else entrega?.zona ?: "Domicilio"
+            deliveryAddress.isNotBlank() -> deliveryAddress
+            entrega != null -> entrega.zona
             else -> "Pasan/Caminando"
         }
         val clienteNombre = user.nombre.ifBlank { "Cliente" }
@@ -248,6 +250,12 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
             descuentoTOTODO = total.value - precioTOTODO
         }
 
+        val resolvedDeliveryAddress = when {
+            deliveryAddress.isNotBlank() -> deliveryAddress
+            currentDeliveryService != null -> currentDeliveryService.zona
+            else -> ""
+        }
+
         val orderEntity = OrderEntity(
             itemsJson = itemsJson,
             total = total.value,
@@ -257,7 +265,7 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
             isDeliveried = isDeliveried,
             dessertsJson = dessertsJson,
             comentarios = comentarios.value,
-            deliveryAddress = deliveryAddress,
+            deliveryAddress = resolvedDeliveryAddress,
             isTOTODO = isTOTODO,
             precioTOTODO = precioTOTODO,
             descuentoTOTODO = descuentoTOTODO

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
@@ -227,13 +227,8 @@ fun OrderListScreen(
                         }
                         item { Spacer(modifier = Modifier.height(16.dp)) }
                         item { HorizontalDivider(thickness = 1.dp, color = Color.Gray) }
-                        if (order.isDeliveried) {
-                            item { Spacer(modifier = Modifier.height(8.dp)) }
-                            item { Text("Envío: ${order.deliveryAddress}") }
-                        } else {
-                            item { Spacer(modifier = Modifier.height(8.dp)) }
-                            item { Text("Pasan o Caminando!") }
-                        }
+                        item { Spacer(modifier = Modifier.height(8.dp)) }
+                        item { Text("Tipo de envío: ${orderViewModel.getDeliverySummary(order)}") }
                         item {
                             Row(
                                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderViewModel.kt
@@ -182,6 +182,20 @@ class OrderViewModel(application: Application) : AndroidViewModel(application) {
         return if (index >= 0) index + 1 else 0
     }
 
+    fun getDeliverySummary(order: OrderEntity): String {
+        val trimmedAddress = order.deliveryAddress.trim()
+        if (trimmedAddress.isNotEmpty()) {
+            return trimmedAddress
+        }
+
+        return when {
+            order.isTOTODO -> "TOTODO"
+            order.isDeliveried -> "Envío a domicilio"
+            order.deliveryServicePrice == 0 -> "Pasan/Caminando"
+            else -> "Recoge en tienda"
+        }
+    }
+
 
     fun buildOrderTicket(order: OrderEntity): String {
         val info = PizzeriaData.info
@@ -199,7 +213,7 @@ class OrderViewModel(application: Application) : AndroidViewModel(application) {
         }
         sb.appendLine("-------------------------------")
         sb.appendLine("Cliente: ${user?.nombre ?: "Cliente"}")
-        sb.appendLine("Direccion: ${if (order.isDeliveried && order.deliveryAddress.isNotBlank()) order.deliveryAddress else "Recoge en tienda"}")
+        sb.appendLine("Direccion: ${getDeliverySummary(order)}")
         sb.appendLine("-------------------------------")
         cartItems.forEach { item ->
             sb.appendLine(
@@ -237,7 +251,7 @@ class OrderViewModel(application: Application) : AndroidViewModel(application) {
         sb.appendLine(
             "Hora: ${SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(order.timestamp))} - Orden: ${getDailyOrderNumber(order)}"
         )
-        sb.appendLine("Cliente: ${user?.nombre ?: "Cliente"} - ${if (order.isDeliveried && order.deliveryAddress.isNotBlank()) order.deliveryAddress else "Pasan/Caminando"}")
+        sb.appendLine("Cliente: ${user?.nombre ?: "Cliente"} - ${getDeliverySummary(order)}")
         sb.appendLine("-------------------------------")
         cartItems.forEach { item ->
             sb.appendLine("${item.cantidad}x ${item.pizza.nombre} ${item.tamano.nombre.uppercase(
@@ -283,13 +297,8 @@ class OrderViewModel(application: Application) : AndroidViewModel(application) {
             sb.appendLine("Comentarios:")
             sb.appendLine(order.comentarios)
         }
-        if (order.isDeliveried) {
-            sb.appendLine("-------------------------------")
-            sb.appendLine("Envío a: ${order.deliveryAddress}")
-        } else {
-            sb.appendLine("-------------------------------")
-            sb.appendLine("Recogida en tienda")
-        }
+        sb.appendLine("-------------------------------")
+        sb.appendLine("Envío/Entrega: ${getDeliverySummary(order)}")
         sb.appendLine("-------------------------------")
         sb.appendLine("¡Orden eliminada correctamente!")
         return sb.toString()


### PR DESCRIPTION
## Summary
- persist the selected delivery zone when saving orders so pickup and TOTODO options are stored
- reuse a single helper to show the delivery type across tickets and the order detail view
- ensure kitchen tickets fall back to the selected delivery service when no address is provided

## Testing
- ⚠️ `./gradlew :app:assembleDebug` *(fails in container: Android SDK not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2d940740832bab289813a7150b85