### PR TITLE
Add walking delivery support and icon

### DIFF
--- a/app/src/main/java/com/alos895/simplepos/data/repository/OrderRepository.kt
+++ b/app/src/main/java/com/alos895/simplepos/data/repository/OrderRepository.kt
@@ -14,7 +14,7 @@ class OrderRepository(context: Context) {
         context,
         AppDatabase::class.java,
         "simplepos.db"
-    ).addMigrations(AppDatabase.MIGRATION_4_5)
+    ).addMigrations(AppDatabase.MIGRATION_4_5, AppDatabase.MIGRATION_5_6)
         .fallbackToDestructiveMigration(true)
         .build()
 
@@ -70,6 +70,7 @@ class OrderRepository(context: Context) {
             userJson = order.userJson,
             deliveryServicePrice = order.deliveryServicePrice,
             isDeliveried = order.isDeliveried,
+            isWalkingDelivery = order.isWalkingDelivery,
             dessertsJson = order.dessertsJson,
             comentarios = order.comentarios,
             deliveryAddress = order.deliveryAddress,

--- a/app/src/main/java/com/alos895/simplepos/db/AppDatabase.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/AppDatabase.kt
@@ -15,7 +15,7 @@ import com.alos895.simplepos.db.entity.OrderEntity
         OrderEntity::class,
         TransactionEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -47,6 +47,18 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                try {
+                    database.execSQL("ALTER TABLE orders ADD COLUMN isWalkingDelivery INTEGER NOT NULL DEFAULT 0")
+                } catch (throwable: Throwable) {
+                    if (throwable.message?.contains("duplicate column name", ignoreCase = true) != true) {
+                        throw throwable
+                    }
+                }
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -54,7 +66,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "simple_pos_database"
                 )
-                    .addMigrations(MIGRATION_4_5)
+                    .addMigrations(MIGRATION_4_5, MIGRATION_5_6)
                     .fallbackToDestructiveMigration(true)
                     .build()
 

--- a/app/src/main/java/com/alos895/simplepos/db/OrderDao.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/OrderDao.kt
@@ -19,7 +19,7 @@ interface OrderDao {
     suspend fun getMaxDailyOrderNumberForRange(start: Long, end: Long): Int?
 
 
-    @Query("UPDATE orders SET itemsJson = :itemsJson, total = :total, timestamp = :timestamp, dailyOrderNumber = :dailyOrderNumber, userJson = :userJson, deliveryServicePrice = :deliveryServicePrice, isDeliveried = :isDeliveried, dessertsJson = :dessertsJson, comentarios = :comentarios, deliveryAddress = :deliveryAddress, pizzaStatus = :pizzaStatus, paymentBreakdownJson= :paymentBreakdownJson, isDeleted = :isDeleted WHERE id = :id")
+    @Query("UPDATE orders SET itemsJson = :itemsJson, total = :total, timestamp = :timestamp, dailyOrderNumber = :dailyOrderNumber, userJson = :userJson, deliveryServicePrice = :deliveryServicePrice, isDeliveried = :isDeliveried, isWalkingDelivery = :isWalkingDelivery, dessertsJson = :dessertsJson, comentarios = :comentarios, deliveryAddress = :deliveryAddress, pizzaStatus = :pizzaStatus, paymentBreakdownJson= :paymentBreakdownJson, isDeleted = :isDeleted WHERE id = :id")
     suspend fun updateOrder(
         id: Long,
         itemsJson: String,
@@ -29,6 +29,7 @@ interface OrderDao {
         userJson: String,
         deliveryServicePrice: Int,
         isDeliveried: Boolean,
+        isWalkingDelivery: Boolean,
         dessertsJson: String,
         comentarios: String,
         deliveryAddress: String,

--- a/app/src/main/java/com/alos895/simplepos/db/entity/OrderEntity.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/entity/OrderEntity.kt
@@ -15,6 +15,7 @@ data class OrderEntity(
     val userJson: String,
     val deliveryServicePrice: Int = 0,
     val isDeliveried: Boolean = false,
+    val isWalkingDelivery: Boolean = false,
     val dessertsJson: String = "[]",
     val comentarios: String = "",
     val deliveryAddress: String = "",

--- a/app/src/main/java/com/alos895/simplepos/ui/menu/CartViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/menu/CartViewModel.kt
@@ -308,6 +308,7 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
         val deliveryPrice = _selectedDelivery.value?.price ?: 0
         val isDeliveried = deliveryPrice > 0
         val currentDeliveryService = _selectedDelivery.value
+        val isWalkingDelivery = currentDeliveryService?.zona.equals("Caminando", ignoreCase = true)
         var isTOTODO = false
         var precioTOTODO = 0.0
         var descuentoTOTODO = 0.0
@@ -324,6 +325,7 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
             userJson = userJson,
             deliveryServicePrice = deliveryPrice,
             isDeliveried = isDeliveried,
+            isWalkingDelivery = isWalkingDelivery,
             dessertsJson = dessertsJson,
             comentarios = comentarios.value,
             deliveryAddress = deliveryAddress,

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessAlarm
 import androidx.compose.material.icons.filled.AddBusiness
+import androidx.compose.material.icons.filled.DirectionsWalk
 import androidx.compose.material.icons.filled.Motorcycle
 import androidx.compose.material3.*
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -165,6 +166,14 @@ fun OrderListScreen(
                                         Icon(
                                             imageVector = Icons.Filled.Motorcycle,
                                             contentDescription = "Para llevar",
+                                            tint = MaterialTheme.colorScheme.secondary,
+                                            modifier = Modifier.padding(bottom = 4.dp)
+                                        )
+                                    }
+                                    if (order.isWalkingDelivery) {
+                                        Icon(
+                                            imageVector = Icons.Filled.DirectionsWalk,
+                                            contentDescription = "Entrega caminando",
                                             tint = MaterialTheme.colorScheme.secondary,
                                             modifier = Modifier.padding(bottom = 4.dp)
                                         )


### PR DESCRIPTION
## Summary
- persist a walking delivery flag on orders and migrate the database schema
- capture the walking delivery selection when saving orders
- display a walking person icon for walking deliveries in the order list

## Testing
- `./gradlew test` *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc36eab9a4832bb3b2ff5d34fcf474