### PR TITLE
Normalize delivery types and persist selection

### DIFF
--- a/app/src/main/java/com/alos895/simplepos/data/repository/OrderRepository.kt
+++ b/app/src/main/java/com/alos895/simplepos/data/repository/OrderRepository.kt
@@ -14,7 +14,7 @@ class OrderRepository(context: Context) {
         context,
         AppDatabase::class.java,
         "simplepos.db"
-    ).addMigrations(AppDatabase.MIGRATION_4_5)
+    ).addMigrations(AppDatabase.MIGRATION_4_5, AppDatabase.MIGRATION_5_6)
         .fallbackToDestructiveMigration(true)
         .build()
 
@@ -73,9 +73,13 @@ class OrderRepository(context: Context) {
             dessertsJson = order.dessertsJson,
             comentarios = order.comentarios,
             deliveryAddress = order.deliveryAddress,
+            deliveryType = order.deliveryType,
             pizzaStatus = order.pizzaStatus,
             isDeleted = order.isDeleted,
-            paymentBreakdownJson = order.paymentBreakdownJson
+            paymentBreakdownJson = order.paymentBreakdownJson,
+            isTOTODO = order.isTOTODO,
+            precioTOTODO = order.precioTOTODO,
+            descuentoTOTODO = order.descuentoTOTODO
         )
     }
 

--- a/app/src/main/java/com/alos895/simplepos/db/AppDatabase.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/AppDatabase.kt
@@ -15,7 +15,7 @@ import com.alos895.simplepos.db.entity.OrderEntity
         OrderEntity::class,
         TransactionEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -47,6 +47,18 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                try {
+                    database.execSQL("ALTER TABLE orders ADD COLUMN deliveryType TEXT NOT NULL DEFAULT 'PASAN'")
+                } catch (throwable: Throwable) {
+                    if (throwable.message?.contains("duplicate column name", ignoreCase = true) != true) {
+                        throw throwable
+                    }
+                }
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -54,7 +66,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "simple_pos_database"
                 )
-                    .addMigrations(MIGRATION_4_5)
+                    .addMigrations(MIGRATION_4_5, MIGRATION_5_6)
                     .fallbackToDestructiveMigration(true)
                     .build()
 

--- a/app/src/main/java/com/alos895/simplepos/db/OrderDao.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/OrderDao.kt
@@ -19,7 +19,7 @@ interface OrderDao {
     suspend fun getMaxDailyOrderNumberForRange(start: Long, end: Long): Int?
 
 
-    @Query("UPDATE orders SET itemsJson = :itemsJson, total = :total, timestamp = :timestamp, dailyOrderNumber = :dailyOrderNumber, userJson = :userJson, deliveryServicePrice = :deliveryServicePrice, isDeliveried = :isDeliveried, dessertsJson = :dessertsJson, comentarios = :comentarios, deliveryAddress = :deliveryAddress, pizzaStatus = :pizzaStatus, paymentBreakdownJson= :paymentBreakdownJson, isDeleted = :isDeleted WHERE id = :id")
+    @Query("UPDATE orders SET itemsJson = :itemsJson, total = :total, timestamp = :timestamp, dailyOrderNumber = :dailyOrderNumber, userJson = :userJson, deliveryServicePrice = :deliveryServicePrice, isDeliveried = :isDeliveried, dessertsJson = :dessertsJson, comentarios = :comentarios, deliveryAddress = :deliveryAddress, deliveryType = :deliveryType, pizzaStatus = :pizzaStatus, paymentBreakdownJson = :paymentBreakdownJson, isDeleted = :isDeleted, isTOTODO = :isTOTODO, precioTOTODO = :precioTOTODO, descuentoTOTODO = :descuentoTOTODO WHERE id = :id")
     suspend fun updateOrder(
         id: Long,
         itemsJson: String,
@@ -32,9 +32,13 @@ interface OrderDao {
         dessertsJson: String,
         comentarios: String,
         deliveryAddress: String,
+        deliveryType: String,
         pizzaStatus: String,
         isDeleted: Boolean,
-        paymentBreakdownJson : String
+        paymentBreakdownJson : String,
+        isTOTODO: Boolean,
+        precioTOTODO: Double,
+        descuentoTOTODO: Double
     )
 
     @Query("UPDATE orders SET paymentBreakdownJson = :paymentBreakdownJson WHERE id = :id")

--- a/app/src/main/java/com/alos895/simplepos/db/entity/OrderEntity.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/entity/OrderEntity.kt
@@ -3,6 +3,7 @@ package com.alos895.simplepos.db.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.alos895.simplepos.model.DeliveryType
 
 @Entity(tableName = "orders")
 data class OrderEntity(
@@ -18,6 +19,8 @@ data class OrderEntity(
     val dessertsJson: String = "[]",
     val comentarios: String = "",
     val deliveryAddress: String = "",
+    @ColumnInfo(defaultValue = "'PASAN'")
+    val deliveryType: String = DeliveryType.PASAN.dbValue,
     val pizzaStatus: String = "",
     val isDeleted: Boolean = false,
     var paymentBreakdownJson: String = "[]",

--- a/app/src/main/java/com/alos895/simplepos/model/DeliveryType.kt
+++ b/app/src/main/java/com/alos895/simplepos/model/DeliveryType.kt
@@ -1,0 +1,18 @@
+package com.alos895.simplepos.model
+
+enum class DeliveryType(
+    val dbValue: String,
+    val displayName: String
+) {
+    PASAN("PASAN", "Pasan"),
+    CAMINANDO("CAMINANDO", "Caminando"),
+    TOTODO("TOTODO", "TOTODO"),
+    A_DOMICILIO("A_DOMICILIO", "A domicilio");
+
+    companion object {
+        fun fromDb(value: String): DeliveryType {
+            return entries.firstOrNull { it.dbValue.equals(value.trim(), ignoreCase = true) }
+                ?: PASAN
+        }
+    }
+}

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderViewModel.kt
@@ -11,6 +11,7 @@ import com.alos895.simplepos.model.CartItem
 import com.alos895.simplepos.model.CartItemPostre
 import com.alos895.simplepos.model.PaymentMethod
 import com.alos895.simplepos.model.PaymentPart
+import com.alos895.simplepos.model.DeliveryType
 import com.alos895.simplepos.model.User
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -184,15 +185,16 @@ class OrderViewModel(application: Application) : AndroidViewModel(application) {
 
     fun getDeliverySummary(order: OrderEntity): String {
         val trimmedAddress = order.deliveryAddress.trim()
-        if (trimmedAddress.isNotEmpty()) {
-            return trimmedAddress
-        }
+        val deliveryType = DeliveryType.fromDb(order.deliveryType)
 
-        return when {
-            order.isTOTODO -> "TOTODO"
-            order.isDeliveried -> "Envío a domicilio"
-            order.deliveryServicePrice == 0 -> "Pasan/Caminando"
-            else -> "Recoge en tienda"
+        return when (deliveryType) {
+            DeliveryType.PASAN -> DeliveryType.PASAN.displayName
+            DeliveryType.CAMINANDO ->
+                if (trimmedAddress.isNotEmpty()) trimmedAddress else DeliveryType.CAMINANDO.displayName
+            DeliveryType.TOTODO ->
+                if (trimmedAddress.isNotEmpty()) trimmedAddress else DeliveryType.TOTODO.displayName
+            DeliveryType.A_DOMICILIO ->
+                if (trimmedAddress.isNotEmpty()) trimmedAddress else DeliveryType.A_DOMICILIO.displayName
         }
     }
 


### PR DESCRIPTION
## Summary
- define a DeliveryType enum and store a canonical value for every order with updated defaults and migration
- capture the delivery type when creating or editing orders, treating Caminando/TOTODO/A domicilio consistently and keeping TOTODO pricing metadata
- update DAO/repository plumbing and order summaries to rely on the persisted delivery type instead of recomputing it in the UI

## Testing
- ./gradlew test *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deafb4d3e4832b920ebbce0e2dc9db