### PR TITLE
Persist delivery type metadata in database

### DIFF
--- a/app/src/main/java/com/alos895/simplepos/data/datasource/MenuData.kt
+++ b/app/src/main/java/com/alos895/simplepos/data/datasource/MenuData.kt
@@ -1,6 +1,7 @@
 package com.alos895.simplepos.data.datasource
 
 import com.alos895.simplepos.model.DeliveryService
+import com.alos895.simplepos.model.DeliveryType
 import com.alos895.simplepos.model.Pizza
 import com.alos895.simplepos.model.Ingrediente
 import com.alos895.simplepos.model.TamanoPizza
@@ -248,58 +249,68 @@ object MenuData {
             price = 0,
             zona = "Pasan",
             description = "Recoge tu pedido en la pizzería.",
-            pickUp = true
+            pickUp = true,
+            type = DeliveryType.PASAN
         ),
         DeliveryService(
             price = 0,
             zona = "Caminando",
-            description = "La llevamos caminando sin costo."
+            description = "La llevamos caminando sin costo.",
+            type = DeliveryType.CAMINANDO
         ),
         DeliveryService(
             price = 0,
             zona = "TOTODO",
             description = "Envio TOTODO.",
-            isTOTODO = true
+            type = DeliveryType.TOTODO
         ),
         DeliveryService(
             price = 25,
             zona = "Zona 1",
-            description = ""
+            description = "",
+            type = DeliveryType.DOMICILIO
         ),
         DeliveryService(
             price = 30,
             zona = "Zona 2",
-            description = ""
+            description = "",
+            type = DeliveryType.DOMICILIO
         ),
         DeliveryService(
             price = 35,
             zona = "Zona 3",
-            description = ""
+            description = "",
+            type = DeliveryType.DOMICILIO
         ),
         DeliveryService(
             price = 40,
             zona = "Zona 4",
-            description = ""
+            description = "",
+            type = DeliveryType.DOMICILIO
         ),
         DeliveryService(
             price = 45,
             zona = "Zona 5",
-            description = ""
+            description = "",
+            type = DeliveryType.DOMICILIO
         ),
         DeliveryService(
             price = 50,
             zona = "Zona 6",
-            description = ""
+            description = "",
+            type = DeliveryType.DOMICILIO
         ),
         DeliveryService(
             price = 55,
             zona = "Zona 7",
-            description = ""
+            description = "",
+            type = DeliveryType.DOMICILIO
         ),
         DeliveryService(
             price = 60,
             zona = "Zona 8",
-            description = ""
+            description = "",
+            type = DeliveryType.DOMICILIO
         )
     )
 }

--- a/app/src/main/java/com/alos895/simplepos/data/repository/OrderRepository.kt
+++ b/app/src/main/java/com/alos895/simplepos/data/repository/OrderRepository.kt
@@ -14,7 +14,11 @@ class OrderRepository(context: Context) {
         context,
         AppDatabase::class.java,
         "simplepos.db"
-    ).addMigrations(AppDatabase.MIGRATION_4_5, AppDatabase.MIGRATION_5_6)
+    ).addMigrations(
+        AppDatabase.MIGRATION_4_5,
+        AppDatabase.MIGRATION_5_6,
+        AppDatabase.MIGRATION_6_7
+    )
         .fallbackToDestructiveMigration(true)
         .build()
 
@@ -76,7 +80,11 @@ class OrderRepository(context: Context) {
             deliveryAddress = order.deliveryAddress,
             pizzaStatus = order.pizzaStatus,
             isDeleted = order.isDeleted,
-            paymentBreakdownJson = order.paymentBreakdownJson
+            paymentBreakdownJson = order.paymentBreakdownJson,
+            deliveryType = order.deliveryType,
+            isTOTODO = order.isTOTODO,
+            precioTOTODO = order.precioTOTODO,
+            descuentoTOTODO = order.descuentoTOTODO
         )
     }
 

--- a/app/src/main/java/com/alos895/simplepos/db/AppDatabase.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/AppDatabase.kt
@@ -15,7 +15,7 @@ import com.alos895.simplepos.db.entity.OrderEntity
         OrderEntity::class,
         TransactionEntity::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -59,6 +59,18 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_6_7 = object : Migration(6, 7) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                try {
+                    database.execSQL("ALTER TABLE orders ADD COLUMN deliveryType TEXT NOT NULL DEFAULT 'PASAN'")
+                } catch (throwable: Throwable) {
+                    if (throwable.message?.contains("duplicate column name", ignoreCase = true) != true) {
+                        throw throwable
+                    }
+                }
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -66,7 +78,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "simple_pos_database"
                 )
-                    .addMigrations(MIGRATION_4_5, MIGRATION_5_6)
+                    .addMigrations(MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
                     .fallbackToDestructiveMigration(true)
                     .build()
 

--- a/app/src/main/java/com/alos895/simplepos/db/Converters.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/Converters.kt
@@ -1,6 +1,7 @@
 package com.alos895.simplepos.db
 
 import androidx.room.TypeConverter
+import com.alos895.simplepos.model.DeliveryType
 import java.util.Date
 
 class Converters {
@@ -12,5 +13,17 @@ class Converters {
     @TypeConverter
     fun dateToTimestamp(date: Date?): Long? {
         return date?.time
+    }
+
+    @TypeConverter
+    fun fromDeliveryType(value: DeliveryType?): String? {
+        return value?.name
+    }
+
+    @TypeConverter
+    fun toDeliveryType(value: String?): DeliveryType {
+        return value?.let {
+            runCatching { DeliveryType.valueOf(it) }.getOrDefault(DeliveryType.PASAN)
+        } ?: DeliveryType.PASAN
     }
 }

--- a/app/src/main/java/com/alos895/simplepos/db/OrderDao.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/OrderDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
 import com.alos895.simplepos.db.entity.OrderEntity
+import com.alos895.simplepos.model.DeliveryType
 
 @Dao
 interface OrderDao {
@@ -19,7 +20,7 @@ interface OrderDao {
     suspend fun getMaxDailyOrderNumberForRange(start: Long, end: Long): Int?
 
 
-    @Query("UPDATE orders SET itemsJson = :itemsJson, total = :total, timestamp = :timestamp, dailyOrderNumber = :dailyOrderNumber, userJson = :userJson, deliveryServicePrice = :deliveryServicePrice, isDeliveried = :isDeliveried, isWalkingDelivery = :isWalkingDelivery, dessertsJson = :dessertsJson, comentarios = :comentarios, deliveryAddress = :deliveryAddress, pizzaStatus = :pizzaStatus, paymentBreakdownJson= :paymentBreakdownJson, isDeleted = :isDeleted WHERE id = :id")
+    @Query("UPDATE orders SET itemsJson = :itemsJson, total = :total, timestamp = :timestamp, dailyOrderNumber = :dailyOrderNumber, userJson = :userJson, deliveryServicePrice = :deliveryServicePrice, isDeliveried = :isDeliveried, isWalkingDelivery = :isWalkingDelivery, dessertsJson = :dessertsJson, comentarios = :comentarios, deliveryAddress = :deliveryAddress, pizzaStatus = :pizzaStatus, paymentBreakdownJson= :paymentBreakdownJson, isDeleted = :isDeleted, deliveryType = :deliveryType, isTOTODO = :isTOTODO, precioTOTODO = :precioTOTODO, descuentoTOTODO = :descuentoTOTODO WHERE id = :id")
     suspend fun updateOrder(
         id: Long,
         itemsJson: String,
@@ -35,7 +36,11 @@ interface OrderDao {
         deliveryAddress: String,
         pizzaStatus: String,
         isDeleted: Boolean,
-        paymentBreakdownJson : String
+        paymentBreakdownJson : String,
+        deliveryType: DeliveryType,
+        isTOTODO: Boolean,
+        precioTOTODO: Double,
+        descuentoTOTODO: Double
     )
 
     @Query("UPDATE orders SET paymentBreakdownJson = :paymentBreakdownJson WHERE id = :id")

--- a/app/src/main/java/com/alos895/simplepos/db/entity/OrderEntity.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/entity/OrderEntity.kt
@@ -3,6 +3,7 @@ package com.alos895.simplepos.db.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.alos895.simplepos.model.DeliveryType
 
 @Entity(tableName = "orders")
 data class OrderEntity(
@@ -19,6 +20,8 @@ data class OrderEntity(
     val dessertsJson: String = "[]",
     val comentarios: String = "",
     val deliveryAddress: String = "",
+    @ColumnInfo(defaultValue = "'PASAN'")
+    val deliveryType: DeliveryType = DeliveryType.PASAN,
     val pizzaStatus: String = "",
     val isDeleted: Boolean = false,
     var paymentBreakdownJson: String = "[]",

--- a/app/src/main/java/com/alos895/simplepos/model/DeliveryService.kt
+++ b/app/src/main/java/com/alos895/simplepos/model/DeliveryService.kt
@@ -5,6 +5,6 @@ data class DeliveryService(
     val description: String,
     val zona: String,
     val pickUp: Boolean = false,
-    var isTOTODO: Boolean = false
+    val type: DeliveryType
 )
 

--- a/app/src/main/java/com/alos895/simplepos/model/DeliveryType.kt
+++ b/app/src/main/java/com/alos895/simplepos/model/DeliveryType.kt
@@ -1,0 +1,8 @@
+package com.alos895.simplepos.model
+
+enum class DeliveryType {
+    PASAN,
+    CAMINANDO,
+    TOTODO,
+    DOMICILIO
+}

--- a/app/src/main/java/com/alos895/simplepos/ui/caja/CajaViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/caja/CajaViewModel.kt
@@ -227,12 +227,15 @@ class CajaViewModel(application: Application) : AndroidViewModel(application) {
                 }
             }
 
-            if (order.isDeliveried) {
-                totalDelivery++
-                deliveryRevenue += order.deliveryServicePrice
-            }
-            if (order.isTOTODO) {
-                deliverysTOTODO++
+            when (order.deliveryType) {
+                DeliveryType.DOMICILIO -> {
+                    totalDelivery++
+                    deliveryRevenue += order.deliveryServicePrice
+                }
+                DeliveryType.TOTODO -> {
+                    deliverysTOTODO++
+                }
+                else -> {}
             }
 
             totalCaja += order.total

--- a/app/src/main/java/com/alos895/simplepos/ui/menu/CartViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/menu/CartViewModel.kt
@@ -326,7 +326,9 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
 
         val resolvedDeliveryAddress = when {
             deliveryAddress.isNotBlank() -> deliveryAddress
-            currentDeliveryService != null -> currentDeliveryService.zona
+            currentDeliveryService != null &&
+                (deliveryType == DeliveryType.DOMICILIO || deliveryType == DeliveryType.CAMINANDO) ->
+                currentDeliveryService.zona
             else -> ""
         }
 

--- a/app/src/main/java/com/alos895/simplepos/ui/menu/CartViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/menu/CartViewModel.kt
@@ -250,6 +250,7 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
         timestamp: Long,
         dailyOrderNumber: Int
     ): String {
+        // Si la orden no tiene pizzas, no se imprime el ticket
         val cartItems = _cartItems.value
         val desserts = _dessertItems.value
         val formatter = SimpleDateFormat("HH:mm", Locale.getDefault())
@@ -269,9 +270,7 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
         val sb = StringBuilder()
         sb.appendLine("ORDEN PARA COCINA")
         sb.appendLine("Hora: $hora - Orden: $dailyOrderNumber")
-        sb.appendLine("Cliente: $clienteNombre")
-        sb.appendLine("Entrega: $deliveryTypeLabel")
-        detail?.let { sb.appendLine("$detailLabel: $it") }
+        sb.appendLine("Cliente: $clienteNombre : $deliveryTypeLabel")
         sb.appendLine("-------------------------------")
 
         if (cartItems.isEmpty()) {
@@ -358,10 +357,10 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun getDeliveryTypeLabel(type: DeliveryType): String {
         return when (type) {
-            DeliveryType.PASAN -> "Recoge en pizzería"
-            DeliveryType.CAMINANDO -> "Entrega caminando"
+            DeliveryType.PASAN -> "PASAN"
+            DeliveryType.CAMINANDO -> "CAMINANDO"
             DeliveryType.TOTODO -> "TOTODO"
-            DeliveryType.DOMICILIO -> "Envío a domicilio"
+            DeliveryType.DOMICILIO -> "ENVIO"
         }
     }
 

--- a/app/src/main/java/com/alos895/simplepos/ui/menu/CartViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/menu/CartViewModel.kt
@@ -13,6 +13,7 @@ import com.alos895.simplepos.model.CartItem
 import com.alos895.simplepos.model.CartItemPortion
 import com.alos895.simplepos.model.CartItemPostre
 import com.alos895.simplepos.model.DeliveryService
+import com.alos895.simplepos.model.DeliveryType
 import com.alos895.simplepos.model.Pizza
 import com.alos895.simplepos.model.PostreOrExtra
 import com.alos895.simplepos.model.TamanoPizza
@@ -307,17 +308,20 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
         val itemsJson = gson.toJson(_cartItems.value)
         val dessertsJson = gson.toJson(_dessertItems.value)
         val userJson = gson.toJson(user)
-        val deliveryPrice = _selectedDelivery.value?.price ?: 0
-        val isDeliveried = deliveryPrice > 0
         val currentDeliveryService = _selectedDelivery.value
-        val isWalkingDelivery = currentDeliveryService?.zona.equals("Caminando", ignoreCase = true)
-        var isTOTODO = false
-        var precioTOTODO = 0.0
-        var descuentoTOTODO = 0.0
-        if (currentDeliveryService?.isTOTODO == true) {
-            isTOTODO = true
+        val deliveryType = currentDeliveryService?.type ?: DeliveryType.PASAN
+        val deliveryPrice = currentDeliveryService?.price ?: 0
+        val isDeliveried = deliveryType == DeliveryType.DOMICILIO
+        val isWalkingDelivery = deliveryType == DeliveryType.CAMINANDO
+        val isTOTODO = deliveryType == DeliveryType.TOTODO
+        val precioTOTODO: Double
+        val descuentoTOTODO: Double
+        if (isTOTODO) {
             precioTOTODO = calculateTOTODOPrice(total.value)
             descuentoTOTODO = total.value - precioTOTODO
+        } else {
+            precioTOTODO = 0.0
+            descuentoTOTODO = 0.0
         }
 
         val resolvedDeliveryAddress = when {
@@ -337,6 +341,7 @@ class CartViewModel(application: Application) : AndroidViewModel(application) {
             dessertsJson = dessertsJson,
             comentarios = comentarios.value,
             deliveryAddress = resolvedDeliveryAddress,
+            deliveryType = deliveryType,
             isTOTODO = isTOTODO,
             precioTOTODO = precioTOTODO,
             descuentoTOTODO = descuentoTOTODO

--- a/app/src/main/java/com/alos895/simplepos/ui/menu/MenuScreen.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/menu/MenuScreen.kt
@@ -512,7 +512,6 @@ fun MenuScreen(
                                 }
 
                                 val requiresAddress = selectedDelivery?.type == DeliveryType.DOMICILIO ||
-                                    selectedDelivery?.type == DeliveryType.TOTODO ||
                                     selectedDelivery?.type == DeliveryType.CAMINANDO
                                 if (requiresAddress) {
                                     Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/alos895/simplepos/ui/menu/MenuScreen.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/menu/MenuScreen.kt
@@ -511,7 +511,9 @@ fun MenuScreen(
                                     }
                                 }
 
-                                val requiresAddress = selectedDelivery?.type == DeliveryType.DOMICILIO || selectedDelivery?.type == DeliveryType.TOTODO
+                                val requiresAddress = selectedDelivery?.type == DeliveryType.DOMICILIO ||
+                                    selectedDelivery?.type == DeliveryType.TOTODO ||
+                                    selectedDelivery?.type == DeliveryType.CAMINANDO
                                 if (requiresAddress) {
                                     Spacer(modifier = Modifier.height(16.dp))
                                     OutlinedTextField(

--- a/app/src/main/java/com/alos895/simplepos/ui/menu/MenuScreen.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/menu/MenuScreen.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.alos895.simplepos.ui.print.BluetoothPrinterViewModel
 import com.alos895.simplepos.data.datasource.MenuData
 import com.alos895.simplepos.model.User
+import com.alos895.simplepos.model.DeliveryType
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -510,8 +511,8 @@ fun MenuScreen(
                                     }
                                 }
 
-                                // Caja de dirección solo si el precio > 0
-                                if ((selectedDelivery?.price ?: 0) > 0) {
+                                val requiresAddress = selectedDelivery?.type == DeliveryType.DOMICILIO || selectedDelivery?.type == DeliveryType.TOTODO
+                                if (requiresAddress) {
                                     Spacer(modifier = Modifier.height(16.dp))
                                     OutlinedTextField(
                                         value = deliveryAddress,

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
@@ -244,7 +244,10 @@ fun OrderListScreen(
                         item { Spacer(modifier = Modifier.height(16.dp)) }
                         item { HorizontalDivider(thickness = 1.dp, color = Color.Gray) }
                         item { Spacer(modifier = Modifier.height(8.dp)) }
-                        item { Text("Tipo de envío: ${orderViewModel.getDeliverySummary(order)}") }
+                        item { Text("Tipo de envío: ${orderViewModel.getDeliveryTypeLabel(order)}") }
+                        orderViewModel.getDeliveryDetail(order)?.let { detail ->
+                            item { Text("Detalle de envío: $detail") }
+                        }
                         item {
                             Row(
                                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
@@ -313,18 +313,20 @@ fun OrderListScreen(
                                     Text("Pagar en Efectivo")
                                 }
 
-                                Button(
-                                    onClick = {
-                                        order.paymentBreakdownJson = "[]"
-                                        orderViewModel.updatePayment(order, order.total, PaymentMethod.TRANSFERENCIA)
-                                        coroutineScope.launch {
-                                            snackbarHostState.showSnackbar("Pago con tarjeta registrado")
-                                        }
-                                        selectedOrder = null
-                                    },
-                                    modifier = Modifier.weight(1f)
-                                ) {
-                                    Text("Pagar con Tarjeta")
+                                if (order.deliveryType != DeliveryType.TOTODO) {
+                                    Button(
+                                        onClick = {
+                                            order.paymentBreakdownJson = "[]"
+                                            orderViewModel.updatePayment(order, order.total, PaymentMethod.TRANSFERENCIA)
+                                            coroutineScope.launch {
+                                                snackbarHostState.showSnackbar("Pago con tarjeta registrado")
+                                            }
+                                            selectedOrder = null
+                                        },
+                                        modifier = Modifier.weight(1f)
+                                    ) {
+                                        Text("Pagar con Tarjeta")
+                                    }
                                 }
                             }
                             Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
@@ -460,7 +460,9 @@ fun EditOrderDialog(
     var selectedDelivery by remember(order.id) {
         mutableStateOf(matchedDelivery ?: customDelivery ?: baseDeliveryOptions.first())
     }
-    val requiresAddress = selectedDelivery.type == DeliveryType.DOMICILIO || selectedDelivery.type == DeliveryType.TOTODO
+    val requiresAddress = selectedDelivery.type == DeliveryType.DOMICILIO ||
+        selectedDelivery.type == DeliveryType.TOTODO ||
+        selectedDelivery.type == DeliveryType.CAMINANDO
 
     fun formatDeliveryLabel(delivery: DeliveryService): String {
         return if (delivery.price > 0) "${delivery.zona} - $${delivery.price}" else delivery.zona

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderListScreen.kt
@@ -464,7 +464,6 @@ fun EditOrderDialog(
         mutableStateOf(matchedDelivery ?: customDelivery ?: baseDeliveryOptions.first())
     }
     val requiresAddress = selectedDelivery.type == DeliveryType.DOMICILIO ||
-        selectedDelivery.type == DeliveryType.TOTODO ||
         selectedDelivery.type == DeliveryType.CAMINANDO
 
     fun formatDeliveryLabel(delivery: DeliveryService): String {

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderViewModel.kt
@@ -190,12 +190,22 @@ class OrderViewModel(application: Application) : AndroidViewModel(application) {
             return trimmedAddress
         }
 
+        return getDeliveryTypeLabel(order)
+    }
+
+    fun getDeliveryTypeLabel(order: OrderEntity): String {
         return when (order.deliveryType) {
             DeliveryType.PASAN -> "Recoge en pizzería"
             DeliveryType.CAMINANDO -> "Entrega caminando"
             DeliveryType.TOTODO -> "TOTODO"
             DeliveryType.DOMICILIO -> "Envío a domicilio"
         }
+    }
+
+    fun getDeliveryDetail(order: OrderEntity): String? {
+        val summary = getDeliverySummary(order)
+        val typeLabel = getDeliveryTypeLabel(order)
+        return summary.takeIf { it.isNotBlank() && it != typeLabel }
     }
 
 
@@ -253,7 +263,12 @@ class OrderViewModel(application: Application) : AndroidViewModel(application) {
         sb.appendLine(
             "Hora: ${SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(order.timestamp))} - Orden: ${getDailyOrderNumber(order)}"
         )
-        sb.appendLine("Cliente: ${user?.nombre ?: "Cliente"} - ${getDeliverySummary(order)}")
+        sb.appendLine("Cliente: ${user?.nombre ?: "Cliente"}")
+        sb.appendLine("Entrega: ${getDeliveryTypeLabel(order)}")
+        getDeliveryDetail(order)?.let { detail ->
+            val detailLabel = if (order.deliveryAddress.trim().isNotEmpty()) "Dirección" else "Detalle"
+            sb.appendLine("$detailLabel: $detail")
+        }
         sb.appendLine("-------------------------------")
         cartItems.forEach { item ->
             CartItemFormatter.toKitchenLines(item).forEach { line ->

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderViewModel.kt
@@ -195,10 +195,10 @@ class OrderViewModel(application: Application) : AndroidViewModel(application) {
 
     fun getDeliveryTypeLabel(order: OrderEntity): String {
         return when (order.deliveryType) {
-            DeliveryType.PASAN -> "Recoge en pizzería"
-            DeliveryType.CAMINANDO -> "Entrega caminando"
+            DeliveryType.PASAN -> "PASAN"
+            DeliveryType.CAMINANDO -> "CAMINANDO"
             DeliveryType.TOTODO -> "TOTODO"
-            DeliveryType.DOMICILIO -> "Envío a domicilio"
+            DeliveryType.DOMICILIO -> "ENVIO"
         }
     }
 
@@ -263,12 +263,7 @@ class OrderViewModel(application: Application) : AndroidViewModel(application) {
         sb.appendLine(
             "Hora: ${SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(order.timestamp))} - Orden: ${getDailyOrderNumber(order)}"
         )
-        sb.appendLine("Cliente: ${user?.nombre ?: "Cliente"}")
-        sb.appendLine("Entrega: ${getDeliveryTypeLabel(order)}")
-        getDeliveryDetail(order)?.let { detail ->
-            val detailLabel = if (order.deliveryAddress.trim().isNotEmpty()) "Dirección" else "Detalle"
-            sb.appendLine("$detailLabel: $detail")
-        }
+        sb.appendLine("Cliente: ${user?.nombre ?: "Cliente"} : ${getDeliveryTypeLabel(order)}")
         sb.appendLine("-------------------------------")
         cartItems.forEach { item ->
             CartItemFormatter.toKitchenLines(item).forEach { line ->

--- a/app/src/main/java/com/alos895/simplepos/ui/orders/OrderViewModel.kt
+++ b/app/src/main/java/com/alos895/simplepos/ui/orders/OrderViewModel.kt
@@ -11,6 +11,7 @@ import com.alos895.simplepos.model.CartItem
 import com.alos895.simplepos.model.CartItemPostre
 import com.alos895.simplepos.model.PaymentMethod
 import com.alos895.simplepos.model.PaymentPart
+import com.alos895.simplepos.model.DeliveryType
 import com.alos895.simplepos.model.User
 import com.google.gson.Gson
 import com.alos895.simplepos.ui.common.CartItemFormatter
@@ -189,11 +190,11 @@ class OrderViewModel(application: Application) : AndroidViewModel(application) {
             return trimmedAddress
         }
 
-        return when {
-            order.isTOTODO -> "TOTODO"
-            order.isDeliveried -> "Envío a domicilio"
-            order.deliveryServicePrice == 0 -> "Pasan/Caminando"
-            else -> "Recoge en tienda"
+        return when (order.deliveryType) {
+            DeliveryType.PASAN -> "Recoge en pizzería"
+            DeliveryType.CAMINANDO -> "Entrega caminando"
+            DeliveryType.TOTODO -> "TOTODO"
+            DeliveryType.DOMICILIO -> "Envío a domicilio"
         }
     }
 


### PR DESCRIPTION
## Summary
- add a DeliveryType model and persist the selected value on OrderEntity with a Room migration
- update repositories, converters, and DAOs so view models and reports reuse the stored delivery type
- refresh menu and order management UIs to drive icons, address requirements, and editing logic from the saved delivery type

## Testing
- ./gradlew test *(fails: SDK location not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68deb9efc2ac832b819a1c5acd66cf3c