### PR TITLE
Room DB migration to v2 and exclude DB files from backups

### DIFF
--- a/app/src/main/java/com/alos895/simplepos/db/AppDatabase.kt
+++ b/app/src/main/java/com/alos895/simplepos/db/AppDatabase.kt
@@ -5,6 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.alos895.simplepos.db.entity.*
 
 @Database(
@@ -18,7 +20,7 @@ import com.alos895.simplepos.db.entity.*
         PizzaBaseEntity::class,
         OrderItemEntity::class
     ],
-    version = 1, // Reset a Versión 1 para lanzamiento
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -44,13 +46,72 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     DB_NAME
                 )
-                // Esto borrará versiones viejas de desarrollo (5, 6, etc.) y empezará de cero en la 1
+                .addMigrations(MIGRATION_1_2)
+                // Fallback para builds de desarrollo muy viejos (5, 6, etc.)
                 .fallbackToDestructiveMigration(true)
                 .fallbackToDestructiveMigrationOnDowngrade(true)
                 .build()
 
                 INSTANCE = instance
                 instance
+            }
+        }
+
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                createOrderItemsTableIfMissing(db)
+                ensureOrderColumns(db)
+            }
+
+            private fun createOrderItemsTableIfMissing(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `order_items` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `orderId` INTEGER NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `type` TEXT NOT NULL,
+                        `size` TEXT,
+                        `quantity` INTEGER NOT NULL,
+                        `unitPrice` REAL NOT NULL,
+                        `subtotal` REAL NOT NULL,
+                        `flavor` TEXT,
+                        `isCombined` INTEGER NOT NULL DEFAULT 0,
+                        FOREIGN KEY(`orderId`) REFERENCES `orders`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+            }
+
+            private fun ensureOrderColumns(db: SupportSQLiteDatabase) {
+                addColumnIfMissing(db, "orders", "dailyOrderNumber", "INTEGER NOT NULL DEFAULT 0")
+                addColumnIfMissing(db, "orders", "deliveryType", "TEXT NOT NULL DEFAULT 'PASAN'")
+                addColumnIfMissing(db, "orders", "isDeleted", "INTEGER NOT NULL DEFAULT 0")
+                addColumnIfMissing(db, "orders", "paymentBreakdownJson", "TEXT NOT NULL DEFAULT '[]'")
+                addColumnIfMissing(db, "orders", "isTOTODO", "INTEGER NOT NULL DEFAULT 0")
+                addColumnIfMissing(db, "orders", "precioTOTODO", "REAL NOT NULL DEFAULT 0.0")
+                addColumnIfMissing(db, "orders", "descuentoTOTODO", "REAL NOT NULL DEFAULT 0.0")
+            }
+
+            private fun addColumnIfMissing(
+                db: SupportSQLiteDatabase,
+                tableName: String,
+                columnName: String,
+                columnDefinition: String
+            ) {
+                val columnExists = db.query("PRAGMA table_info(`$tableName`)").use { cursor ->
+                    val nameIndex = cursor.getColumnIndex("name")
+                    while (cursor.moveToNext()) {
+                        if (cursor.getString(nameIndex) == columnName) {
+                            return@use true
+                        }
+                    }
+                    false
+                }
+
+                if (!columnExists) {
+                    db.execSQL("ALTER TABLE `$tableName` ADD COLUMN `$columnName` $columnDefinition")
+                }
             }
         }
     }

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older than API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <!-- Evita restaurar una BD antigua/incompatible después de reinstalar o actualizar -->
+    <exclude domain="database" path="simplepos.db" />
+    <exclude domain="database" path="simplepos.db-wal" />
+    <exclude domain="database" path="simplepos.db-shm" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <!-- Evita restaurar una BD antigua/incompatible -->
+        <exclude domain="database" path="simplepos.db" />
+        <exclude domain="database" path="simplepos.db-wal" />
+        <exclude domain="database" path="simplepos.db-shm" />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="database" path="simplepos.db" />
+        <exclude domain="database" path="simplepos.db-wal" />
+        <exclude domain="database" path="simplepos.db-shm" />
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
### Motivation
- Bump the Room schema to version 2 to introduce the missing `order_items` table and new `orders` columns without losing compatible user data.
- Prevent restoring incompatible or very old database files during auto-backup or data transfer which could crash the app after reinstalls or upgrades.

### Description
- Incremented Room database `version` to `2` and registered a `MIGRATION_1_2` object in `AppDatabase` that creates the `order_items` table if missing and conditionally adds several new `orders` columns using `PRAGMA table_info` checks.
- Added `addMigrations(MIGRATION_1_2)` to the Room builder while retaining `fallbackToDestructiveMigration(true)` and `fallbackToDestructiveMigrationOnDowngrade(true)` as a fallback for very old development DBs.
- Updated `backup_rules.xml` and `data_extraction_rules.xml` to exclude `simplepos.db`, `simplepos.db-wal`, and `simplepos.db-shm` from backups and data transfers to avoid restoring incompatible database files.

### Testing
- Ran a Gradle assemble with `./gradlew assembleDebug` which completed successfully. 
- Executed unit tests with `./gradlew test` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d9813160832ba94eea388a3abf90)